### PR TITLE
Update binary_encoder.go

### DIFF
--- a/ua/binary_encoder.go
+++ b/ua/binary_encoder.go
@@ -10,10 +10,10 @@ import (
 	"sync"
 	"time"
 	"unsafe"
+	"fmt"
 
 	"github.com/djherbis/buffer"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -156,7 +156,7 @@ func getEncoder(typ reflect.Type) (encoderFunc, error) {
 	case reflect.String:
 		return getStringEncoder()
 	}
-	return nil, errors.Errorf("unsupported type: %s\n", typ)
+	return nil, fmt.Errorf("unsupported type: %s\n", typ)
 }
 
 func getStructEncoder(typ reflect.Type) (encoderFunc, error) {


### PR DESCRIPTION
Switched to native go fmt instead of pkg errors (less dependencies) and since there are no complex errors, pkg errors adds only  overhead