### PR TITLE
Update enums.generated.go

### DIFF
--- a/ua/enums.generated.go
+++ b/ua/enums.generated.go
@@ -122,7 +122,7 @@ func (v IdentityCriteriaType) String() string {
 }
 
 // TrustListMasks enumeration.
-type TrustListMasks int32
+type TrustListMasks uint32
 
 // TrustListMasks enumeration.
 const (


### PR DESCRIPTION
TrustListMasks should be of type uint32

https://reference.opcfoundation.org/GDS/v105/docs/7.8.2.6#Table28