### PR TITLE
[codex] implement reverse connect

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"fmt"
+	"net"
 	"os"
 	"sort"
 
@@ -50,12 +51,26 @@ func Dial(ctx context.Context, endpointURL string, opts ...Option) (c *Client, e
 		}
 	}
 
+	var reverseListener net.Listener
+	if cli.reverseConnectURL != "" {
+		reverseListener, err = listenReverse(cli.reverseConnectURL)
+		if err != nil {
+			return nil, err
+		}
+		defer reverseListener.Close()
+	}
+
 	// get endpoints from discovery url
 	req := &ua.GetEndpointsRequest{
 		EndpointURL: endpointURL,
 		ProfileURIs: []string{ua.TransportProfileURIUaTcpTransport},
 	}
-	res, err := GetEndpoints(ctx, req)
+	var res *ua.GetEndpointsResponse
+	if reverseListener != nil {
+		res, err = getEndpointsReverse(ctx, req, reverseListener, endpointURL, cli.connectTimeout)
+	} else {
+		res, err = GetEndpoints(ctx, req)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -142,6 +157,14 @@ func Dial(ctx context.Context, endpointURL string, opts ...Option) (c *Client, e
 		cli.maxChunkCount,
 		cli.trace)
 
+	if reverseListener != nil {
+		conn, err := acceptReverse(ctx, reverseListener, endpointURL, cli.connectTimeout)
+		if err != nil {
+			return nil, err
+		}
+		cli.channel.conn = conn
+	}
+
 	// open session and read the namespace table
 	if err := cli.open(ctx); err != nil {
 		cli.Abort(ctx)
@@ -187,6 +210,7 @@ type Client struct {
 	maxBufferSize                        uint32
 	maxMessageSize                       uint32
 	maxChunkCount                        uint32
+	reverseConnectURL                    string
 	trace                                bool
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -67,7 +67,7 @@ func Dial(ctx context.Context, endpointURL string, opts ...Option) (c *Client, e
 	}
 	var res *ua.GetEndpointsResponse
 	if reverseListener != nil {
-		res, err = getEndpointsReverse(ctx, req, reverseListener, endpointURL, cli.connectTimeout)
+		res, err = getEndpointsReverse(ctx, req, reverseListener, endpointURL, cli.reverseConnectServerURIs, cli.connectTimeout)
 	} else {
 		res, err = GetEndpoints(ctx, req)
 	}
@@ -158,7 +158,7 @@ func Dial(ctx context.Context, endpointURL string, opts ...Option) (c *Client, e
 		cli.trace)
 
 	if reverseListener != nil {
-		conn, err := acceptReverse(ctx, reverseListener, endpointURL, cli.connectTimeout)
+		conn, err := acceptReverse(ctx, reverseListener, endpointURL, cli.reverseConnectServerURIs, cli.connectTimeout)
 		if err != nil {
 			return nil, err
 		}
@@ -211,6 +211,7 @@ type Client struct {
 	maxMessageSize                       uint32
 	maxChunkCount                        uint32
 	reverseConnectURL                    string
+	reverseConnectServerURIs             []string
 	trace                                bool
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -13,7 +13,6 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"fmt"
-	"net"
 	"os"
 	"sort"
 
@@ -51,13 +50,21 @@ func Dial(ctx context.Context, endpointURL string, opts ...Option) (c *Client, e
 		}
 	}
 
-	var reverseListener net.Listener
+	var reverseManager = cli.reverseConnectManager
+	if cli.reverseConnectURL != "" && reverseManager != nil {
+		return nil, ua.BadInvalidArgument
+	}
 	if cli.reverseConnectURL != "" {
-		reverseListener, err = listenReverse(cli.reverseConnectURL)
+		timeout := reverseConnectDuration(cli.connectTimeout)
+		reverseManager, err = NewReverseConnectManager(
+			cli.reverseConnectURL,
+			WithReverseConnectHoldTime(timeout),
+			WithReverseConnectWaitTimeout(timeout),
+		)
 		if err != nil {
 			return nil, err
 		}
-		defer reverseListener.Close()
+		defer reverseManager.Close()
 	}
 
 	// get endpoints from discovery url
@@ -66,8 +73,8 @@ func Dial(ctx context.Context, endpointURL string, opts ...Option) (c *Client, e
 		ProfileURIs: []string{ua.TransportProfileURIUaTcpTransport},
 	}
 	var res *ua.GetEndpointsResponse
-	if reverseListener != nil {
-		res, err = getEndpointsReverse(ctx, req, reverseListener, endpointURL, cli.reverseConnectServerURIs, cli.connectTimeout)
+	if reverseManager != nil {
+		res, err = getEndpointsReverse(ctx, req, reverseManager, endpointURL, cli.reverseConnectServerURIs, cli.connectTimeout)
 	} else {
 		res, err = GetEndpoints(ctx, req)
 	}
@@ -157,8 +164,8 @@ func Dial(ctx context.Context, endpointURL string, opts ...Option) (c *Client, e
 		cli.maxChunkCount,
 		cli.trace)
 
-	if reverseListener != nil {
-		conn, err := acceptReverse(ctx, reverseListener, endpointURL, cli.reverseConnectServerURIs, cli.connectTimeout)
+	if reverseManager != nil {
+		conn, err := reverseManager.Wait(ctx, endpointURL, cli.reverseConnectServerURIs)
 		if err != nil {
 			return nil, err
 		}
@@ -212,6 +219,7 @@ type Client struct {
 	maxChunkCount                        uint32
 	reverseConnectURL                    string
 	reverseConnectServerURIs             []string
+	reverseConnectManager                *ReverseConnectManager
 	trace                                bool
 }
 

--- a/client/client_secure_channel.go
+++ b/client/client_secure_channel.go
@@ -300,9 +300,11 @@ func (ch *clientSecureChannel) Open(ctx context.Context) error {
 		}
 	}
 
-	ch.conn, err = net.DialTimeout("tcp", remoteURL.Host, time.Duration(ch.connectTimeout)*time.Millisecond)
-	if err != nil {
-		return err
+	if ch.conn == nil {
+		ch.conn, err = net.DialTimeout("tcp", remoteURL.Host, time.Duration(ch.connectTimeout)*time.Millisecond)
+		if err != nil {
+			return err
+		}
 	}
 
 	buf := *(ch.bytesPool.Get().(*[]byte))

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/awcullen/opcua/client"
+	"github.com/awcullen/opcua/server"
 	"github.com/awcullen/opcua/ua"
 
 	"github.com/pkg/errors"
@@ -86,6 +87,60 @@ func TestDiscoveryClient(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestReverseConnectWithoutSecurity(t *testing.T) {
+	serverURL := freeEndpointURL(t)
+	reverseURL := freeEndpointURL(t)
+
+	srv, err := NewTestServerAt(serverURL, server.WithReverseConnectClientURLs([]string{reverseURL}, 25*time.Millisecond))
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "Error constructing reverse connect server"))
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe()
+	}()
+	defer func() {
+		if err := srv.Close(); err != nil {
+			t.Error(errors.Wrap(err, "Error closing reverse connect server"))
+		}
+		if err := <-errCh; err != ua.BadServerHalted {
+			t.Error(errors.Wrap(err, "Error stopping reverse connect server"))
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ch, err := client.Dial(
+		ctx,
+		serverURL,
+		client.WithReverseConnectURL(reverseURL),
+		client.WithInsecureSkipVerify(),
+	)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "Error connecting to server by reverse connect"))
+	}
+	if ch.EndpointURL() != serverURL {
+		t.Fatalf("expected endpoint URL %q, got %q", serverURL, ch.EndpointURL())
+	}
+	if err := ch.Close(ctx); err != nil {
+		ch.Abort(ctx)
+		t.Fatal(errors.Wrap(err, "Error closing reverse connect client"))
+	}
+}
+
+func freeEndpointURL(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return "opc.tcp://" + addr
 }
 
 // TestOpenClientlWithoutSecurity tests opening a connection with a server using no security.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -130,6 +130,49 @@ func TestReverseConnectWithoutSecurity(t *testing.T) {
 	}
 }
 
+func TestReverseConnectWithSecurity(t *testing.T) {
+	serverURL := freeEndpointURL(t)
+	reverseURL := freeEndpointURL(t)
+
+	srv, err := NewTestServerAt(serverURL, server.WithReverseConnectClientURLs([]string{reverseURL}, 25*time.Millisecond))
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "Error constructing reverse connect server"))
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe()
+	}()
+	defer func() {
+		if err := srv.Close(); err != nil {
+			t.Error(errors.Wrap(err, "Error closing reverse connect server"))
+		}
+		if err := <-errCh; err != ua.BadServerHalted {
+			t.Error(errors.Wrap(err, "Error stopping reverse connect server"))
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ch, err := client.Dial(
+		ctx,
+		serverURL,
+		client.WithReverseConnectURL(reverseURL),
+		client.WithClientCertificatePaths("./pki/client.crt", "./pki/client.key"),
+		client.WithInsecureSkipVerify(),
+		client.WithUserNameIdentity("root", "secret"),
+	)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "Error connecting to server by secure reverse connect"))
+	}
+	if ch.SecurityPolicyURI() == ua.SecurityPolicyURINone {
+		t.Fatal("expected secure reverse connect to select a security policy")
+	}
+	if err := ch.Close(ctx); err != nil {
+		ch.Abort(ctx)
+		t.Fatal(errors.Wrap(err, "Error closing secure reverse connect client"))
+	}
+}
+
 func freeEndpointURL(t *testing.T) string {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -54,10 +54,26 @@ func TestMain(m *testing.M) {
 				os.Exit(3)
 			}
 		}()
+		if err := waitForTestServer(endpointURL, 5*time.Second); err != nil {
+			fmt.Println(errors.Wrap(err, "Error starting server"))
+			os.Exit(3)
+		}
 	}
 	// run the tests
 	res := m.Run()
 	defer os.Exit(res)
+}
+
+func waitForTestServer(endpointURL string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		_, err := client.FindServers(context.Background(), &ua.FindServersRequest{EndpointURL: endpointURL})
+		if err == nil {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return ua.BadTimeout
 }
 
 // TestDiscoveryClient discovers connection information about a server.
@@ -170,6 +186,73 @@ func TestReverseConnectWithSecurity(t *testing.T) {
 	if err := ch.Close(ctx); err != nil {
 		ch.Abort(ctx)
 		t.Fatal(errors.Wrap(err, "Error closing secure reverse connect client"))
+	}
+}
+
+func TestReverseConnectWithSharedManager(t *testing.T) {
+	serverURL := freeEndpointURL(t)
+	reverseURL := freeEndpointURL(t)
+
+	mgr, err := client.NewReverseConnectManager(reverseURL)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "Error constructing reverse connect manager"))
+	}
+
+	srv, err := NewTestServerAt(serverURL, server.WithReverseConnectClientURLs([]string{reverseURL}, 25*time.Millisecond))
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "Error constructing reverse connect server"))
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe()
+	}()
+	defer func() {
+		if err := srv.Close(); err != nil {
+			t.Error(errors.Wrap(err, "Error closing reverse connect server"))
+		}
+		if err := <-errCh; err != ua.BadServerHalted {
+			t.Error(errors.Wrap(err, "Error stopping reverse connect server"))
+		}
+	}()
+	defer mgr.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ch, err := client.Dial(
+		ctx,
+		serverURL,
+		client.WithReverseConnectManager(mgr),
+		client.WithInsecureSkipVerify(),
+	)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "Error connecting to server by shared reverse connect manager"))
+	}
+	if ch.EndpointURL() != serverURL {
+		t.Fatalf("expected endpoint URL %q, got %q", serverURL, ch.EndpointURL())
+	}
+	if err := ch.Close(ctx); err != nil {
+		ch.Abort(ctx)
+		t.Fatal(errors.Wrap(err, "Error closing reverse connect client"))
+	}
+}
+
+func TestReverseConnectURLAndManagerAreMutuallyExclusive(t *testing.T) {
+	reverseURL := freeEndpointURL(t)
+	mgr, err := client.NewReverseConnectManager(reverseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close()
+
+	_, err = client.Dial(
+		context.Background(),
+		"opc.tcp://127.0.0.1:4840",
+		client.WithReverseConnectURL(reverseURL),
+		client.WithReverseConnectManager(mgr),
+	)
+	if err != ua.BadInvalidArgument {
+		t.Fatalf("expected %v, got %v", ua.BadInvalidArgument, err)
 	}
 }
 

--- a/client/option.go
+++ b/client/option.go
@@ -235,6 +235,14 @@ func WithReverseConnectServerURIs(values []string) Option {
 	}
 }
 
+// WithReverseConnectManager uses manager to wait for incoming reverse connections.
+func WithReverseConnectManager(manager *ReverseConnectManager) Option {
+	return func(c *Client) error {
+		c.reverseConnectManager = manager
+		return nil
+	}
+}
+
 // WithTrace logs all ServiceRequests and ServiceResponses to StdOut.
 func WithTrace() Option {
 	return func(c *Client) error {

--- a/client/option.go
+++ b/client/option.go
@@ -218,6 +218,15 @@ func WithConnectTimeout(value int64) Option {
 	}
 }
 
+// WithReverseConnectURL listens at the given client URL and waits for the server to initiate the TCP connection.
+// The URL is in the form opc.tcp://[host]:[port].
+func WithReverseConnectURL(value string) Option {
+	return func(c *Client) error {
+		c.reverseConnectURL = value
+		return nil
+	}
+}
+
 // WithTrace logs all ServiceRequests and ServiceResponses to StdOut.
 func WithTrace() Option {
 	return func(c *Client) error {

--- a/client/option.go
+++ b/client/option.go
@@ -227,6 +227,14 @@ func WithReverseConnectURL(value string) Option {
 	}
 }
 
+// WithReverseConnectServerURIs limits reverse connections to servers with matching ApplicationURI values.
+func WithReverseConnectServerURIs(values []string) Option {
+	return func(c *Client) error {
+		c.reverseConnectServerURIs = append(c.reverseConnectServerURIs[:0], values...)
+		return nil
+	}
+}
+
 // WithTrace logs all ServiceRequests and ServiceResponses to StdOut.
 func WithTrace() Option {
 	return func(c *Client) error {

--- a/client/reverse_connect.go
+++ b/client/reverse_connect.go
@@ -1,0 +1,146 @@
+// Copyright 2021 Converter Systems LLC. All rights reserved.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/awcullen/opcua/ua"
+)
+
+type deadlineListener interface {
+	SetDeadline(time.Time) error
+}
+
+func listenReverse(reverseURL string) (net.Listener, error) {
+	u, err := url.Parse(reverseURL)
+	if err != nil {
+		return nil, err
+	}
+	return net.Listen("tcp", u.Host)
+}
+
+func getEndpointsReverse(ctx context.Context, request *ua.GetEndpointsRequest, ln net.Listener, endpointURL string, connectTimeout int64) (*ua.GetEndpointsResponse, error) {
+	ch := newClientSecureChannel(
+		ua.ApplicationDescription{
+			ApplicationName: ua.LocalizedText{Text: "DiscoveryClient"},
+			ApplicationType: ua.ApplicationTypeClient,
+		},
+		nil,
+		nil,
+		request.EndpointURL,
+		ua.SecurityPolicyURINone,
+		ua.MessageSecurityModeNone,
+		nil,
+		connectTimeout,
+		"",
+		"",
+		"",
+		"",
+		"",
+		false,
+		false,
+		false,
+		false,
+		defaultTimeoutHint,
+		defaultDiagnosticsHint,
+		defaultTokenRequestedLifetime,
+		defaultMaxBufferSize,
+		defaultMaxMessageSize,
+		defaultMaxChunkCount,
+		false,
+	)
+	conn, err := acceptReverse(ctx, ln, endpointURL, connectTimeout)
+	if err != nil {
+		return nil, err
+	}
+	ch.conn = conn
+
+	if err := ch.Open(ctx); err != nil {
+		ch.Abort(ctx)
+		return nil, err
+	}
+	res, err := ch.GetEndpoints(ctx, request)
+	if err != nil {
+		ch.Abort(ctx)
+		return nil, err
+	}
+	err = ch.Close(ctx)
+	if err != nil {
+		ch.Abort(ctx)
+		return nil, err
+	}
+	return res, nil
+}
+
+func acceptReverse(ctx context.Context, ln net.Listener, endpointURL string, connectTimeout int64) (net.Conn, error) {
+	deadline := time.Now().Add(time.Duration(connectTimeout) * time.Millisecond)
+	if t, ok := ctx.Deadline(); ok && t.Before(deadline) {
+		deadline = t
+	}
+	if dl, ok := ln.(deadlineListener); ok {
+		_ = dl.SetDeadline(deadline)
+	}
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+				return nil, err
+			}
+		}
+		if err := readReverseHello(conn, endpointURL, deadline); err != nil {
+			conn.Close()
+			if time.Now().After(deadline) {
+				return nil, err
+			}
+			continue
+		}
+		_ = conn.SetDeadline(time.Time{})
+		return conn, nil
+	}
+}
+
+func readReverseHello(conn net.Conn, endpointURL string, deadline time.Time) error {
+	_ = conn.SetReadDeadline(deadline)
+	var header [8]byte
+	if _, err := io.ReadFull(conn, header[:]); err != nil {
+		return err
+	}
+	if binary.LittleEndian.Uint32(header[:4]) != ua.MessageTypeReverseHello {
+		return ua.BadDecodingError
+	}
+	msgLen := binary.LittleEndian.Uint32(header[4:8])
+	if msgLen < 16 || msgLen > defaultMaxBufferSize {
+		return ua.BadDecodingError
+	}
+	buf := make([]byte, msgLen)
+	copy(buf, header[:])
+	if _, err := io.ReadFull(conn, buf[8:]); err != nil {
+		return err
+	}
+
+	reader := bytes.NewReader(buf[8:])
+	dec := ua.NewBinaryDecoder(reader, ua.NewEncodingContext())
+	var serverURI string
+	if err := dec.ReadString(&serverURI); err != nil {
+		return ua.BadDecodingError
+	}
+	var reverseEndpointURL string
+	if err := dec.ReadString(&reverseEndpointURL); err != nil {
+		return ua.BadDecodingError
+	}
+	if reverseEndpointURL != endpointURL {
+		return ua.BadTCPEndpointURLInvalid
+	}
+	return nil
+}

--- a/client/reverse_connect.go
+++ b/client/reverse_connect.go
@@ -5,6 +5,7 @@ package client
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"io"
 	"net"
 	"net/url"
@@ -23,8 +24,292 @@ var reverseRejectBufferPool = sync.Pool{New: func() any {
 	return new([16]byte)
 }}
 
-type deadlineListener interface {
-	SetDeadline(time.Time) error
+const (
+	defaultReverseConnectHoldTime    = 15 * time.Second
+	defaultReverseConnectWaitTimeout = 20 * time.Second
+)
+
+// ReverseConnectManager accepts ReverseHello messages and holds matching connections for clients.
+type ReverseConnectManager struct {
+	endpointURL string
+	ln          net.Listener
+	holdTime    time.Duration
+	waitTimeout time.Duration
+
+	closeOnce sync.Once
+	wg        sync.WaitGroup
+
+	mu      sync.Mutex
+	pending []*reverseConnection
+	notify  chan struct{}
+	closing chan struct{}
+	closed  chan struct{}
+	err     error
+}
+
+// ReverseConnectManagerOption configures a ReverseConnectManager.
+type ReverseConnectManagerOption func(*ReverseConnectManager) error
+
+type reverseConnection struct {
+	conn        net.Conn
+	serverURI   string
+	endpointURL string
+}
+
+// WithReverseConnectHoldTime sets how long incoming ReverseHello sockets are held for a client.
+func WithReverseConnectHoldTime(value time.Duration) ReverseConnectManagerOption {
+	return func(m *ReverseConnectManager) error {
+		if value > 0 {
+			m.holdTime = value
+		}
+		return nil
+	}
+}
+
+// WithReverseConnectWaitTimeout sets how long Wait waits for a matching ReverseHello socket.
+func WithReverseConnectWaitTimeout(value time.Duration) ReverseConnectManagerOption {
+	return func(m *ReverseConnectManager) error {
+		if value > 0 {
+			m.waitTimeout = value
+		}
+		return nil
+	}
+}
+
+// NewReverseConnectManager listens at reverseURL and accepts reverse connections.
+func NewReverseConnectManager(reverseURL string, opts ...ReverseConnectManagerOption) (*ReverseConnectManager, error) {
+	ln, err := listenReverse(reverseURL)
+	if err != nil {
+		return nil, err
+	}
+	m, err := newReverseConnectManager(reverseURL, ln, opts...)
+	if err != nil {
+		ln.Close()
+		return nil, err
+	}
+	return m, nil
+}
+
+func newReverseConnectManager(reverseURL string, ln net.Listener, opts ...ReverseConnectManagerOption) (*ReverseConnectManager, error) {
+	m := &ReverseConnectManager{
+		endpointURL: reverseURL,
+		ln:          ln,
+		holdTime:    defaultReverseConnectHoldTime,
+		waitTimeout: defaultReverseConnectWaitTimeout,
+		notify:      make(chan struct{}),
+		closing:     make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+	for _, opt := range opts {
+		if err := opt(m); err != nil {
+			return nil, err
+		}
+	}
+	go m.serve()
+	return m, nil
+}
+
+// EndpointURL returns the reverse connect endpoint URL.
+func (m *ReverseConnectManager) EndpointURL() string {
+	if m == nil {
+		return ""
+	}
+	return m.endpointURL
+}
+
+// Addr returns the listener network address.
+func (m *ReverseConnectManager) Addr() net.Addr {
+	if m == nil || m.ln == nil {
+		return nil
+	}
+	return m.ln.Addr()
+}
+
+// Close stops the manager and rejects any held reverse connections.
+func (m *ReverseConnectManager) Close() error {
+	if m == nil {
+		return nil
+	}
+	m.closeOnce.Do(func() {
+		close(m.closing)
+		err := m.ln.Close()
+		m.mu.Lock()
+		if m.err == nil && err != nil && !isClosedNetworkError(err) {
+			m.err = err
+		}
+		pending := m.pending
+		m.pending = nil
+		m.notifyLocked()
+		m.mu.Unlock()
+		for _, rc := range pending {
+			_ = writeReverseReject(rc.conn, ua.BadTCPMessageTypeInvalid)
+			rc.conn.Close()
+		}
+		m.wg.Wait()
+		close(m.closed)
+	})
+	<-m.closed
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.err
+}
+
+// Wait returns a held reverse connection matching endpointURL and serverURIs.
+func (m *ReverseConnectManager) Wait(ctx context.Context, endpointURL string, serverURIs []string) (net.Conn, error) {
+	if m == nil {
+		return nil, ua.BadConnectionClosed
+	}
+	if m.waitTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, m.waitTimeout)
+		defer cancel()
+	}
+	for {
+		m.mu.Lock()
+		if rc := m.takeLocked(endpointURL, serverURIs); rc != nil {
+			m.mu.Unlock()
+			return rc.conn, nil
+		}
+		select {
+		case <-m.closing:
+			err := m.err
+			if err == nil {
+				err = ua.BadConnectionClosed
+			}
+			m.mu.Unlock()
+			return nil, err
+		default:
+		}
+		notify := m.notify
+		m.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-notify:
+		}
+	}
+}
+
+func (m *ReverseConnectManager) serve() {
+	for {
+		conn, err := m.ln.Accept()
+		if err != nil {
+			select {
+			case <-m.closing:
+				return
+			default:
+				m.fail(err)
+				return
+			}
+		}
+		m.wg.Add(1)
+		go func() {
+			defer m.wg.Done()
+			m.handle(conn)
+		}()
+	}
+}
+
+func (m *ReverseConnectManager) handle(conn net.Conn) {
+	serverURI, endpointURL, bufp, err := readReverseHello(conn, time.Now().Add(m.holdTime))
+	if bufp != nil {
+		defer reverseHelloBufferPool.Put(bufp)
+	}
+	if err != nil {
+		_ = writeReverseReject(conn, err)
+		conn.Close()
+		return
+	}
+	rc := &reverseConnection{
+		conn:        conn,
+		serverURI:   string(serverURI),
+		endpointURL: string(endpointURL),
+	}
+	m.mu.Lock()
+	select {
+	case <-m.closing:
+		m.mu.Unlock()
+		_ = writeReverseReject(conn, ua.BadTCPMessageTypeInvalid)
+		conn.Close()
+		return
+	default:
+	}
+	m.pending = append(m.pending, rc)
+	m.notifyLocked()
+	holdTime := m.holdTime
+	m.mu.Unlock()
+
+	timer := time.NewTimer(holdTime)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		if m.remove(rc) {
+			_ = writeReverseReject(conn, ua.BadTCPMessageTypeInvalid)
+			conn.Close()
+		}
+	case <-m.closing:
+	}
+}
+
+func (m *ReverseConnectManager) fail(err error) {
+	m.mu.Lock()
+	if m.err == nil && !isClosedNetworkError(err) {
+		m.err = err
+	}
+	m.mu.Unlock()
+	m.Close()
+}
+
+func (m *ReverseConnectManager) takeLocked(endpointURL string, serverURIs []string) *reverseConnection {
+	for i, rc := range m.pending {
+		if reverseConnectionMatches(rc, endpointURL, serverURIs) {
+			last := len(m.pending) - 1
+			m.pending[i] = m.pending[last]
+			m.pending[last] = nil
+			m.pending = m.pending[:last]
+			return rc
+		}
+	}
+	return nil
+}
+
+func (m *ReverseConnectManager) remove(rc *reverseConnection) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, pending := range m.pending {
+		if pending == rc {
+			last := len(m.pending) - 1
+			m.pending[i] = m.pending[last]
+			m.pending[last] = nil
+			m.pending = m.pending[:last]
+			return true
+		}
+	}
+	return false
+}
+
+func (m *ReverseConnectManager) notifyLocked() {
+	close(m.notify)
+	m.notify = make(chan struct{})
+}
+
+func reverseConnectionMatches(rc *reverseConnection, endpointURL string, serverURIs []string) bool {
+	if endpointURL != "" && rc.endpointURL != endpointURL {
+		return false
+	}
+	if len(serverURIs) == 0 {
+		return true
+	}
+	for _, serverURI := range serverURIs {
+		if rc.serverURI == serverURI {
+			return true
+		}
+	}
+	return false
+}
+
+func isClosedNetworkError(err error) bool {
+	return errors.Is(err, net.ErrClosed)
 }
 
 func listenReverse(reverseURL string) (net.Listener, error) {
@@ -35,7 +320,14 @@ func listenReverse(reverseURL string) (net.Listener, error) {
 	return net.Listen("tcp", u.Host)
 }
 
-func getEndpointsReverse(ctx context.Context, request *ua.GetEndpointsRequest, ln net.Listener, endpointURL string, serverURIs []string, connectTimeout int64) (*ua.GetEndpointsResponse, error) {
+func reverseConnectDuration(value int64) time.Duration {
+	if value <= 0 {
+		value = defaultConnectTimeout
+	}
+	return time.Duration(value) * time.Millisecond
+}
+
+func getEndpointsReverse(ctx context.Context, request *ua.GetEndpointsRequest, manager *ReverseConnectManager, endpointURL string, serverURIs []string, connectTimeout int64) (*ua.GetEndpointsResponse, error) {
 	ch := newClientSecureChannel(
 		ua.ApplicationDescription{
 			ApplicationName: ua.LocalizedText{Text: "DiscoveryClient"},
@@ -65,7 +357,7 @@ func getEndpointsReverse(ctx context.Context, request *ua.GetEndpointsRequest, l
 		defaultMaxChunkCount,
 		false,
 	)
-	conn, err := acceptReverse(ctx, ln, endpointURL, serverURIs, connectTimeout)
+	conn, err := manager.Wait(ctx, endpointURL, serverURIs)
 	if err != nil {
 		return nil, err
 	}
@@ -89,35 +381,18 @@ func getEndpointsReverse(ctx context.Context, request *ua.GetEndpointsRequest, l
 }
 
 func acceptReverse(ctx context.Context, ln net.Listener, endpointURL string, serverURIs []string, connectTimeout int64) (net.Conn, error) {
-	deadline := time.Now().Add(time.Duration(connectTimeout) * time.Millisecond)
-	if t, ok := ctx.Deadline(); ok && t.Before(deadline) {
-		deadline = t
+	timeout := reverseConnectDuration(connectTimeout)
+	manager, err := newReverseConnectManager(
+		"",
+		ln,
+		WithReverseConnectHoldTime(timeout),
+		WithReverseConnectWaitTimeout(timeout),
+	)
+	if err != nil {
+		return nil, err
 	}
-	if dl, ok := ln.(deadlineListener); ok {
-		_ = dl.SetDeadline(deadline)
-	}
-
-	for {
-		conn, err := ln.Accept()
-		if err != nil {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			default:
-				return nil, err
-			}
-		}
-		if err := validateReverseHello(conn, endpointURL, serverURIs, deadline); err != nil {
-			_ = writeReverseReject(conn, err)
-			conn.Close()
-			if time.Now().After(deadline) {
-				return nil, err
-			}
-			continue
-		}
-		_ = conn.SetDeadline(time.Time{})
-		return conn, nil
-	}
+	defer manager.Close()
+	return manager.Wait(ctx, endpointURL, serverURIs)
 }
 
 func validateReverseHello(conn net.Conn, endpointURL string, serverURIs []string, deadline time.Time) error {

--- a/client/reverse_connect.go
+++ b/client/reverse_connect.go
@@ -3,24 +3,28 @@
 package client
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"io"
 	"net"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/awcullen/opcua/ua"
 )
 
+var reverseHelloBufferPool = sync.Pool{New: func() any {
+	buf := make([]byte, defaultMaxBufferSize)
+	return &buf
+}}
+
+var reverseRejectBufferPool = sync.Pool{New: func() any {
+	return new([16]byte)
+}}
+
 type deadlineListener interface {
 	SetDeadline(time.Time) error
-}
-
-type reverseHello struct {
-	serverURI   string
-	endpointURL string
 }
 
 func listenReverse(reverseURL string) (net.Listener, error) {
@@ -117,54 +121,85 @@ func acceptReverse(ctx context.Context, ln net.Listener, endpointURL string, ser
 }
 
 func validateReverseHello(conn net.Conn, endpointURL string, serverURIs []string, deadline time.Time) error {
-	hello, err := readReverseHello(conn, deadline)
+	serverURI, reverseEndpointURL, bufp, err := readReverseHello(conn, deadline)
+	if bufp != nil {
+		defer reverseHelloBufferPool.Put(bufp)
+	}
 	if err != nil {
 		return err
 	}
-	if hello.endpointURL != endpointURL {
+	if !equalBytesString(reverseEndpointURL, endpointURL) {
 		return ua.BadTCPMessageTypeInvalid
 	}
 	if len(serverURIs) == 0 {
 		return nil
 	}
-	for _, serverURI := range serverURIs {
-		if hello.serverURI == serverURI {
+	for _, expectedServerURI := range serverURIs {
+		if equalBytesString(serverURI, expectedServerURI) {
 			return nil
 		}
 	}
 	return ua.BadTCPMessageTypeInvalid
 }
 
-func readReverseHello(conn net.Conn, deadline time.Time) (reverseHello, error) {
+func readReverseHello(conn net.Conn, deadline time.Time) ([]byte, []byte, *[]byte, error) {
 	_ = conn.SetReadDeadline(deadline)
 	var header [8]byte
 	if _, err := io.ReadFull(conn, header[:]); err != nil {
-		return reverseHello{}, err
+		return nil, nil, nil, err
 	}
 	if binary.LittleEndian.Uint32(header[:4]) != ua.MessageTypeReverseHello {
-		return reverseHello{}, ua.BadTCPMessageTypeInvalid
+		return nil, nil, nil, ua.BadTCPMessageTypeInvalid
 	}
 	msgLen := binary.LittleEndian.Uint32(header[4:8])
 	if msgLen < 16 || msgLen > defaultMaxBufferSize {
-		return reverseHello{}, ua.BadDecodingError
+		return nil, nil, nil, ua.BadDecodingError
 	}
-	buf := make([]byte, msgLen)
-	copy(buf, header[:])
-	if _, err := io.ReadFull(conn, buf[8:]); err != nil {
-		return reverseHello{}, err
+	bodyLen := int(msgLen - 8)
+	bufp := reverseHelloBufferPool.Get().(*[]byte)
+	buf := (*bufp)[:bodyLen]
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		reverseHelloBufferPool.Put(bufp)
+		return nil, nil, nil, err
 	}
 
-	reader := bytes.NewReader(buf[8:])
-	dec := ua.NewBinaryDecoder(reader, ua.NewEncodingContext())
-	var serverURI string
-	if err := dec.ReadString(&serverURI); err != nil {
-		return reverseHello{}, ua.BadDecodingError
+	serverURI, n, err := readReverseHelloString(buf)
+	if err != nil {
+		reverseHelloBufferPool.Put(bufp)
+		return nil, nil, nil, err
 	}
-	var reverseEndpointURL string
-	if err := dec.ReadString(&reverseEndpointURL); err != nil {
-		return reverseHello{}, ua.BadDecodingError
+	reverseEndpointURL, _, err := readReverseHelloString(buf[n:])
+	if err != nil {
+		reverseHelloBufferPool.Put(bufp)
+		return nil, nil, nil, err
 	}
-	return reverseHello{serverURI: serverURI, endpointURL: reverseEndpointURL}, nil
+	return serverURI, reverseEndpointURL, bufp, nil
+}
+
+func readReverseHelloString(buf []byte) ([]byte, int, error) {
+	if len(buf) < 4 {
+		return nil, 0, ua.BadDecodingError
+	}
+	n := int(int32(binary.LittleEndian.Uint32(buf[:4])))
+	if n < 0 {
+		return nil, 4, nil
+	}
+	if n > len(buf)-4 {
+		return nil, 0, ua.BadDecodingError
+	}
+	return buf[4 : 4+n], 4 + n, nil
+}
+
+func equalBytesString(value []byte, expected string) bool {
+	if len(value) != len(expected) {
+		return false
+	}
+	for i, b := range value {
+		if expected[i] != b {
+			return false
+		}
+	}
+	return true
 }
 
 func writeReverseReject(conn net.Conn, reason error) error {
@@ -172,12 +207,14 @@ func writeReverseReject(conn net.Conn, reason error) error {
 	if !ok {
 		code = ua.BadTCPMessageTypeInvalid
 	}
-	var buf [16]byte
+	bufp := reverseRejectBufferPool.Get().(*[16]byte)
+	defer reverseRejectBufferPool.Put(bufp)
+	buf := bufp[:]
 	binary.LittleEndian.PutUint32(buf[0:4], ua.MessageTypeError)
 	binary.LittleEndian.PutUint32(buf[4:8], uint32(16))
 	binary.LittleEndian.PutUint32(buf[8:12], uint32(code))
 	binary.LittleEndian.PutUint32(buf[12:16], 0xFFFFFFFF)
 	_ = conn.SetWriteDeadline(time.Now().Add(3 * time.Second))
-	_, err := conn.Write(buf[:])
+	_, err := conn.Write(buf)
 	return err
 }

--- a/client/reverse_connect.go
+++ b/client/reverse_connect.go
@@ -18,6 +18,11 @@ type deadlineListener interface {
 	SetDeadline(time.Time) error
 }
 
+type reverseHello struct {
+	serverURI   string
+	endpointURL string
+}
+
 func listenReverse(reverseURL string) (net.Listener, error) {
 	u, err := url.Parse(reverseURL)
 	if err != nil {
@@ -26,7 +31,7 @@ func listenReverse(reverseURL string) (net.Listener, error) {
 	return net.Listen("tcp", u.Host)
 }
 
-func getEndpointsReverse(ctx context.Context, request *ua.GetEndpointsRequest, ln net.Listener, endpointURL string, connectTimeout int64) (*ua.GetEndpointsResponse, error) {
+func getEndpointsReverse(ctx context.Context, request *ua.GetEndpointsRequest, ln net.Listener, endpointURL string, serverURIs []string, connectTimeout int64) (*ua.GetEndpointsResponse, error) {
 	ch := newClientSecureChannel(
 		ua.ApplicationDescription{
 			ApplicationName: ua.LocalizedText{Text: "DiscoveryClient"},
@@ -56,7 +61,7 @@ func getEndpointsReverse(ctx context.Context, request *ua.GetEndpointsRequest, l
 		defaultMaxChunkCount,
 		false,
 	)
-	conn, err := acceptReverse(ctx, ln, endpointURL, connectTimeout)
+	conn, err := acceptReverse(ctx, ln, endpointURL, serverURIs, connectTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +84,7 @@ func getEndpointsReverse(ctx context.Context, request *ua.GetEndpointsRequest, l
 	return res, nil
 }
 
-func acceptReverse(ctx context.Context, ln net.Listener, endpointURL string, connectTimeout int64) (net.Conn, error) {
+func acceptReverse(ctx context.Context, ln net.Listener, endpointURL string, serverURIs []string, connectTimeout int64) (net.Conn, error) {
 	deadline := time.Now().Add(time.Duration(connectTimeout) * time.Millisecond)
 	if t, ok := ctx.Deadline(); ok && t.Before(deadline) {
 		deadline = t
@@ -98,7 +103,8 @@ func acceptReverse(ctx context.Context, ln net.Listener, endpointURL string, con
 				return nil, err
 			}
 		}
-		if err := readReverseHello(conn, endpointURL, deadline); err != nil {
+		if err := validateReverseHello(conn, endpointURL, serverURIs, deadline); err != nil {
+			_ = writeReverseReject(conn, err)
 			conn.Close()
 			if time.Now().After(deadline) {
 				return nil, err
@@ -110,37 +116,68 @@ func acceptReverse(ctx context.Context, ln net.Listener, endpointURL string, con
 	}
 }
 
-func readReverseHello(conn net.Conn, endpointURL string, deadline time.Time) error {
+func validateReverseHello(conn net.Conn, endpointURL string, serverURIs []string, deadline time.Time) error {
+	hello, err := readReverseHello(conn, deadline)
+	if err != nil {
+		return err
+	}
+	if hello.endpointURL != endpointURL {
+		return ua.BadTCPMessageTypeInvalid
+	}
+	if len(serverURIs) == 0 {
+		return nil
+	}
+	for _, serverURI := range serverURIs {
+		if hello.serverURI == serverURI {
+			return nil
+		}
+	}
+	return ua.BadTCPMessageTypeInvalid
+}
+
+func readReverseHello(conn net.Conn, deadline time.Time) (reverseHello, error) {
 	_ = conn.SetReadDeadline(deadline)
 	var header [8]byte
 	if _, err := io.ReadFull(conn, header[:]); err != nil {
-		return err
+		return reverseHello{}, err
 	}
 	if binary.LittleEndian.Uint32(header[:4]) != ua.MessageTypeReverseHello {
-		return ua.BadDecodingError
+		return reverseHello{}, ua.BadTCPMessageTypeInvalid
 	}
 	msgLen := binary.LittleEndian.Uint32(header[4:8])
 	if msgLen < 16 || msgLen > defaultMaxBufferSize {
-		return ua.BadDecodingError
+		return reverseHello{}, ua.BadDecodingError
 	}
 	buf := make([]byte, msgLen)
 	copy(buf, header[:])
 	if _, err := io.ReadFull(conn, buf[8:]); err != nil {
-		return err
+		return reverseHello{}, err
 	}
 
 	reader := bytes.NewReader(buf[8:])
 	dec := ua.NewBinaryDecoder(reader, ua.NewEncodingContext())
 	var serverURI string
 	if err := dec.ReadString(&serverURI); err != nil {
-		return ua.BadDecodingError
+		return reverseHello{}, ua.BadDecodingError
 	}
 	var reverseEndpointURL string
 	if err := dec.ReadString(&reverseEndpointURL); err != nil {
-		return ua.BadDecodingError
+		return reverseHello{}, ua.BadDecodingError
 	}
-	if reverseEndpointURL != endpointURL {
-		return ua.BadTCPEndpointURLInvalid
+	return reverseHello{serverURI: serverURI, endpointURL: reverseEndpointURL}, nil
+}
+
+func writeReverseReject(conn net.Conn, reason error) error {
+	code, ok := reason.(ua.StatusCode)
+	if !ok {
+		code = ua.BadTCPMessageTypeInvalid
 	}
-	return nil
+	var buf [16]byte
+	binary.LittleEndian.PutUint32(buf[0:4], ua.MessageTypeError)
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(16))
+	binary.LittleEndian.PutUint32(buf[8:12], uint32(code))
+	binary.LittleEndian.PutUint32(buf[12:16], 0xFFFFFFFF)
+	_ = conn.SetWriteDeadline(time.Now().Add(3 * time.Second))
+	_, err := conn.Write(buf[:])
+	return err
 }

--- a/client/reverse_connect_test.go
+++ b/client/reverse_connect_test.go
@@ -68,8 +68,54 @@ func TestAcceptReverseRejectsEndpointMismatchWithError(t *testing.T) {
 	}
 }
 
+func BenchmarkReadReverseHello(b *testing.B) {
+	msg := testReverseHelloBytes("urn:server", "opc.tcp://127.0.0.1:4840")
+	deadline := time.Now().Add(time.Hour)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		conn := &staticConn{buf: msg}
+		_, _, bufp, err := readReverseHello(conn, deadline)
+		if bufp != nil {
+			reverseHelloBufferPool.Put(bufp)
+		}
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValidateReverseHelloServerURIFilter(b *testing.B) {
+	msg := testReverseHelloBytes("urn:server", "opc.tcp://127.0.0.1:4840")
+	deadline := time.Now().Add(time.Hour)
+	serverURIs := []string{"urn:other", "urn:server"}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		conn := &staticConn{buf: msg}
+		if err := validateReverseHello(conn, "opc.tcp://127.0.0.1:4840", serverURIs, deadline); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWriteReverseReject(b *testing.B) {
+	conn := discardConn{}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := writeReverseReject(conn, ua.BadTCPMessageTypeInvalid); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func writeTestReverseHello(t *testing.T, conn net.Conn, serverURI, endpointURL string) {
 	t.Helper()
+	buf := testReverseHelloBytes(serverURI, endpointURL)
+	if _, err := conn.Write(buf); err != nil {
+		t.Error(err)
+	}
+}
+
+func testReverseHelloBytes(serverURI, endpointURL string) []byte {
 	msgLen := 16 + len(serverURI) + len(endpointURL)
 	buf := make([]byte, msgLen)
 	binary.LittleEndian.PutUint32(buf[0:4], ua.MessageTypeReverseHello)
@@ -79,9 +125,7 @@ func writeTestReverseHello(t *testing.T, conn net.Conn, serverURI, endpointURL s
 	offset := 12 + len(serverURI)
 	binary.LittleEndian.PutUint32(buf[offset:offset+4], uint32(len(endpointURL)))
 	copy(buf[offset+4:], endpointURL)
-	if _, err := conn.Write(buf); err != nil {
-		t.Error(err)
-	}
+	return buf
 }
 
 func readTestErrorCode(conn net.Conn) (ua.StatusCode, error) {
@@ -98,3 +142,38 @@ func readTestErrorCode(conn net.Conn) (ua.StatusCode, error) {
 func timeContext(timeout time.Duration) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), timeout)
 }
+
+type staticConn struct {
+	buf []byte
+	off int
+}
+
+func (c *staticConn) Close() error                     { return nil }
+func (c *staticConn) LocalAddr() net.Addr              { return testAddr{} }
+func (c *staticConn) RemoteAddr() net.Addr             { return testAddr{} }
+func (c *staticConn) SetDeadline(time.Time) error      { return nil }
+func (c *staticConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *staticConn) SetWriteDeadline(time.Time) error { return nil }
+func (c *staticConn) Write(p []byte) (int, error)      { return len(p), nil }
+func (c *staticConn) Read(p []byte) (int, error) {
+	if c.off >= len(c.buf) {
+		return 0, io.EOF
+	}
+	n := copy(p, c.buf[c.off:])
+	c.off += n
+	return n, nil
+}
+func (c discardConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (c discardConn) Write(p []byte) (int, error)      { return len(p), nil }
+func (c discardConn) Close() error                     { return nil }
+func (c discardConn) LocalAddr() net.Addr              { return testAddr{} }
+func (c discardConn) RemoteAddr() net.Addr             { return testAddr{} }
+func (c discardConn) SetDeadline(time.Time) error      { return nil }
+func (c discardConn) SetReadDeadline(time.Time) error  { return nil }
+func (c discardConn) SetWriteDeadline(time.Time) error { return nil }
+func (a testAddr) Network() string                     { return "test" }
+func (a testAddr) String() string                      { return "test" }
+
+type discardConn struct{}
+
+type testAddr struct{}

--- a/client/reverse_connect_test.go
+++ b/client/reverse_connect_test.go
@@ -1,0 +1,100 @@
+// Copyright 2021 Converter Systems LLC. All rights reserved.
+
+package client
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/awcullen/opcua/ua"
+)
+
+func TestValidateReverseHelloServerURIFilter(t *testing.T) {
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+
+	go writeTestReverseHello(t, remote, "urn:server", "opc.tcp://127.0.0.1:4840")
+
+	err := validateReverseHello(local, "opc.tcp://127.0.0.1:4840", []string{"urn:other"}, time.Now().Add(time.Second))
+	if err != ua.BadTCPMessageTypeInvalid {
+		t.Fatalf("expected %v, got %v", ua.BadTCPMessageTypeInvalid, err)
+	}
+}
+
+func TestAcceptReverseRejectsEndpointMismatchWithError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer conn.Close()
+		writeTestReverseHello(t, conn, "urn:server", "opc.tcp://127.0.0.1:4841")
+		code, err := readTestErrorCode(conn)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if code != ua.BadTCPMessageTypeInvalid {
+			t.Errorf("expected %v, got %v", ua.BadTCPMessageTypeInvalid, code)
+		}
+		errCh <- nil
+	}()
+
+	ctx, cancel := timeContext(200 * time.Millisecond)
+	defer cancel()
+	conn, err := acceptReverse(ctx, ln, "opc.tcp://127.0.0.1:4840", nil, 200)
+	if conn != nil {
+		conn.Close()
+		t.Fatal("expected reverse connection to be rejected")
+	}
+	if err == nil {
+		t.Fatal("expected acceptReverse to return an error after rejecting the only connection")
+	}
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeTestReverseHello(t *testing.T, conn net.Conn, serverURI, endpointURL string) {
+	t.Helper()
+	msgLen := 16 + len(serverURI) + len(endpointURL)
+	buf := make([]byte, msgLen)
+	binary.LittleEndian.PutUint32(buf[0:4], ua.MessageTypeReverseHello)
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(msgLen))
+	binary.LittleEndian.PutUint32(buf[8:12], uint32(len(serverURI)))
+	copy(buf[12:12+len(serverURI)], serverURI)
+	offset := 12 + len(serverURI)
+	binary.LittleEndian.PutUint32(buf[offset:offset+4], uint32(len(endpointURL)))
+	copy(buf[offset+4:], endpointURL)
+	if _, err := conn.Write(buf); err != nil {
+		t.Error(err)
+	}
+}
+
+func readTestErrorCode(conn net.Conn) (ua.StatusCode, error) {
+	var buf [16]byte
+	if _, err := io.ReadFull(conn, buf[:]); err != nil {
+		return 0, err
+	}
+	if binary.LittleEndian.Uint32(buf[0:4]) != ua.MessageTypeError {
+		return 0, ua.BadTCPMessageTypeInvalid
+	}
+	return ua.StatusCode(binary.LittleEndian.Uint32(buf[8:12])), nil
+}
+
+func timeContext(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
+}

--- a/client/reverse_connect_test.go
+++ b/client/reverse_connect_test.go
@@ -68,6 +68,106 @@ func TestAcceptReverseRejectsEndpointMismatchWithError(t *testing.T) {
 	}
 }
 
+func TestReverseConnectManagerHoldsIncomingConnection(t *testing.T) {
+	reverseURL := freeReverseConnectURL(t)
+	mgr, err := NewReverseConnectManager(
+		reverseURL,
+		WithReverseConnectHoldTime(time.Second),
+		WithReverseConnectWaitTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close()
+
+	endpointURL := "opc.tcp://127.0.0.1:4840"
+	remote := dialReverseHello(t, mgr, "urn:server", endpointURL)
+	defer remote.Close()
+
+	time.Sleep(25 * time.Millisecond)
+	ctx, cancel := timeContext(time.Second)
+	defer cancel()
+	conn, err := mgr.Wait(ctx, endpointURL, []string{"urn:server"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if _, err := remote.Write([]byte{0x7f}); err != nil {
+		t.Fatal(err)
+	}
+	var buf [1]byte
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := io.ReadFull(conn, buf[:]); err != nil {
+		t.Fatal(err)
+	}
+	if buf[0] != 0x7f {
+		t.Fatalf("expected 0x7f, got 0x%x", buf[0])
+	}
+}
+
+func TestReverseConnectManagerMatchesEndpointAndServerURI(t *testing.T) {
+	reverseURL := freeReverseConnectURL(t)
+	mgr, err := NewReverseConnectManager(
+		reverseURL,
+		WithReverseConnectHoldTime(time.Second),
+		WithReverseConnectWaitTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close()
+
+	remoteA := dialReverseHello(t, mgr, "urn:a", "opc.tcp://127.0.0.1:4840")
+	defer remoteA.Close()
+	remoteB := dialReverseHello(t, mgr, "urn:b", "opc.tcp://127.0.0.1:4841")
+	defer remoteB.Close()
+
+	ctx, cancel := timeContext(time.Second)
+	defer cancel()
+	conn, err := mgr.Wait(ctx, "opc.tcp://127.0.0.1:4841", []string{"urn:b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if _, err := remoteB.Write([]byte{0x42}); err != nil {
+		t.Fatal(err)
+	}
+	var buf [1]byte
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := io.ReadFull(conn, buf[:]); err != nil {
+		t.Fatal(err)
+	}
+	if buf[0] != 0x42 {
+		t.Fatalf("expected 0x42, got 0x%x", buf[0])
+	}
+}
+
+func TestReverseConnectManagerRejectsUnclaimedConnectionAfterHoldTime(t *testing.T) {
+	reverseURL := freeReverseConnectURL(t)
+	mgr, err := NewReverseConnectManager(
+		reverseURL,
+		WithReverseConnectHoldTime(25*time.Millisecond),
+		WithReverseConnectWaitTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close()
+
+	remote := dialReverseHello(t, mgr, "urn:server", "opc.tcp://127.0.0.1:4840")
+	defer remote.Close()
+	_ = remote.SetReadDeadline(time.Now().Add(time.Second))
+	code, err := readTestErrorCode(remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != ua.BadTCPMessageTypeInvalid {
+		t.Fatalf("expected %v, got %v", ua.BadTCPMessageTypeInvalid, code)
+	}
+}
+
 func BenchmarkReadReverseHello(b *testing.B) {
 	msg := testReverseHelloBytes("urn:server", "opc.tcp://127.0.0.1:4840")
 	deadline := time.Now().Add(time.Hour)
@@ -107,6 +207,17 @@ func BenchmarkWriteReverseReject(b *testing.B) {
 	}
 }
 
+func BenchmarkReverseConnectionMatches(b *testing.B) {
+	rc := &reverseConnection{serverURI: "urn:server", endpointURL: "opc.tcp://127.0.0.1:4840"}
+	serverURIs := []string{"urn:other", "urn:server"}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if !reverseConnectionMatches(rc, "opc.tcp://127.0.0.1:4840", serverURIs) {
+			b.Fatal("expected match")
+		}
+	}
+}
+
 func writeTestReverseHello(t *testing.T, conn net.Conn, serverURI, endpointURL string) {
 	t.Helper()
 	buf := testReverseHelloBytes(serverURI, endpointURL)
@@ -137,6 +248,29 @@ func readTestErrorCode(conn net.Conn) (ua.StatusCode, error) {
 		return 0, ua.BadTCPMessageTypeInvalid
 	}
 	return ua.StatusCode(binary.LittleEndian.Uint32(buf[8:12])), nil
+}
+
+func freeReverseConnectURL(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return "opc.tcp://" + addr
+}
+
+func dialReverseHello(t *testing.T, mgr *ReverseConnectManager, serverURI, endpointURL string) net.Conn {
+	t.Helper()
+	conn, err := net.Dial("tcp", mgr.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestReverseHello(t, conn, serverURI, endpointURL)
+	return conn
 }
 
 func timeContext(timeout time.Duration) (context.Context, context.CancelFunc) {

--- a/client/testserver_test.go
+++ b/client/testserver_test.go
@@ -34,6 +34,10 @@ func init() {
 }
 
 func NewTestServer() (*server.Server, error) {
+	return NewTestServerAt(fmt.Sprintf("opc.tcp://%s:%d", host, port))
+}
+
+func NewTestServerAt(endpointURL string, options ...server.Option) (*server.Server, error) {
 
 	// userids for testing
 	userids := []ua.UserNameIdentity{
@@ -58,48 +62,49 @@ func NewTestServer() (*server.Server, error) {
 			ApplicationType:     ua.ApplicationTypeServer,
 			GatewayServerURI:    "",
 			DiscoveryProfileURI: "",
-			DiscoveryURLs:       []string{fmt.Sprintf("opc.tcp://%s:%d", host, port)},
+			DiscoveryURLs:       []string{endpointURL},
 		},
 		"./pki/server.crt",
 		"./pki/server.key",
-		fmt.Sprintf("opc.tcp://%s:%d", host, port),
-		server.WithBuildInfo(
+		endpointURL,
+		append([]server.Option{server.WithBuildInfo(
 			ua.BuildInfo{
 				ProductURI:       "http://github.com/awcullen/opcua",
 				ManufacturerName: "awcullen",
 				ProductName:      "testserver",
 				SoftwareVersion:  SoftwareVersion,
 			}),
-		server.WithAuthenticateAnonymousIdentityFunc(func(userIdentity ua.AnonymousIdentity, applicationURI string, endpointURL string) error {
-			// log.Printf("Login anonymous identity from %s\n", applicationURI)
-			return nil
-		}),
-		server.WithAuthenticateUserNameIdentityFunc(func(userIdentity ua.UserNameIdentity, applicationURI string, endpointURL string) error {
-			valid := false
-			for _, user := range userids {
-				if user.UserName == userIdentity.UserName {
-					if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(userIdentity.Password)); err == nil {
-						valid = true
-						break
+			server.WithAuthenticateAnonymousIdentityFunc(func(userIdentity ua.AnonymousIdentity, applicationURI string, endpointURL string) error {
+				// log.Printf("Login anonymous identity from %s\n", applicationURI)
+				return nil
+			}),
+			server.WithAuthenticateUserNameIdentityFunc(func(userIdentity ua.UserNameIdentity, applicationURI string, endpointURL string) error {
+				valid := false
+				for _, user := range userids {
+					if user.UserName == userIdentity.UserName {
+						if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(userIdentity.Password)); err == nil {
+							valid = true
+							break
+						}
 					}
 				}
-			}
-			if !valid {
-				return ua.BadUserAccessDenied
-			}
-			// log.Printf("Login %s from %s\n", userIdentity.UserName, applicationURI)
-			return nil
-		}),
-		server.WithAuthenticateX509IdentityFunc(func(userIdentity ua.X509Identity, applicationURI string, endpointURL string) error {
-			_, err := x509.ParseCertificates([]byte(userIdentity.Certificate))
-			if err != nil {
-				return ua.BadUserAccessDenied
-			}
-			// log.Printf("Login %s from %s\n", cert.Subject, applicationURI)
-			return nil
-		}),
-		server.WithSecurityPolicyNone(true),
-		server.WithInsecureSkipVerify(),
+				if !valid {
+					return ua.BadUserAccessDenied
+				}
+				// log.Printf("Login %s from %s\n", userIdentity.UserName, applicationURI)
+				return nil
+			}),
+			server.WithAuthenticateX509IdentityFunc(func(userIdentity ua.X509Identity, applicationURI string, endpointURL string) error {
+				_, err := x509.ParseCertificates([]byte(userIdentity.Certificate))
+				if err != nil {
+					return ua.BadUserAccessDenied
+				}
+				// log.Printf("Login %s from %s\n", cert.Subject, applicationURI)
+				return nil
+			}),
+			server.WithSecurityPolicyNone(true),
+			server.WithInsecureSkipVerify(),
+		}, options...)...,
 	)
 	if err != nil {
 		return nil, err

--- a/server/option.go
+++ b/server/option.go
@@ -113,6 +113,16 @@ func WithReverseConnectClientURLs(urls []string, interval time.Duration) Option 
 	}
 }
 
+// WithReverseConnectRejectTimeout sets how long to wait before retrying a client URL that rejects ReverseHello.
+func WithReverseConnectRejectTimeout(value time.Duration) Option {
+	return func(srv *Server) error {
+		if value > 0 {
+			srv.reverseConnectRejectTimeout = value
+		}
+		return nil
+	}
+}
+
 // WithServerDiagnostics sets whether to enable the collection of data used for ServerDiagnostics node.
 func WithServerDiagnostics(value bool) Option {
 	return func(opts *Server) error {

--- a/server/option.go
+++ b/server/option.go
@@ -113,6 +113,16 @@ func WithReverseConnectClientURLs(urls []string, interval time.Duration) Option 
 	}
 }
 
+// WithReverseConnectTimeout sets how long to wait when dialing a reverse connect client URL.
+func WithReverseConnectTimeout(value time.Duration) Option {
+	return func(srv *Server) error {
+		if value > 0 {
+			srv.reverseConnectTimeout = value
+		}
+		return nil
+	}
+}
+
 // WithReverseConnectRejectTimeout sets how long to wait before retrying a client URL that rejects ReverseHello.
 func WithReverseConnectRejectTimeout(value time.Duration) Option {
 	return func(srv *Server) error {

--- a/server/option.go
+++ b/server/option.go
@@ -2,7 +2,11 @@
 
 package server
 
-import "github.com/awcullen/opcua/ua"
+import (
+	"time"
+
+	"github.com/awcullen/opcua/ua"
+)
 
 // Option is a functional option to be applied to a server during initialization.
 type Option func(*Server) error
@@ -93,6 +97,18 @@ func WithTransportLimits(maxBufferSize, maxMessageSize, maxChunkCount uint32) Op
 func WithMaxWorkerThreads(value int) Option {
 	return func(opts *Server) error {
 		opts.maxWorkerThreads = value
+		return nil
+	}
+}
+
+// WithReverseConnectClientURLs sets the client URLs that the server connects to for reverse connections.
+// The interval controls how often the server retries the configured client URLs.
+func WithReverseConnectClientURLs(urls []string, interval time.Duration) Option {
+	return func(srv *Server) error {
+		srv.reverseConnectURLs = append(srv.reverseConnectURLs[:0], urls...)
+		if interval > 0 {
+			srv.reverseConnectInterval = interval
+		}
 		return nil
 	}
 }

--- a/server/reverse_connect.go
+++ b/server/reverse_connect.go
@@ -45,6 +45,7 @@ func (srv *Server) reverseConnectOnce(ctx context.Context, wg *sync.WaitGroup) {
 	if timeout <= 0 {
 		timeout = 3 * time.Second
 	}
+	now := time.Now()
 	for _, clientURL := range srv.reverseConnectURLs {
 		select {
 		case <-srv.closing:
@@ -55,7 +56,7 @@ func (srv *Server) reverseConnectOnce(ctx context.Context, wg *sync.WaitGroup) {
 		if err != nil {
 			continue
 		}
-		if !srv.beginReverseConnect(clientURL) {
+		if !srv.beginReverseConnect(clientURL, now) {
 			continue
 		}
 		dialCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -70,13 +71,13 @@ func (srv *Server) reverseConnectOnce(ctx context.Context, wg *sync.WaitGroup) {
 	}
 }
 
-func (srv *Server) beginReverseConnect(clientURL string) bool {
+func (srv *Server) beginReverseConnect(clientURL string, now time.Time) bool {
 	srv.reverseConnectMu.Lock()
 	defer srv.reverseConnectMu.Unlock()
 	if srv.reverseConnectActive[clientURL] > 0 {
 		return false
 	}
-	if until := srv.reverseConnectRejectedUntil[clientURL]; time.Now().Before(until) {
+	if until := srv.reverseConnectRejectedUntil[clientURL]; now.Before(until) {
 		return false
 	}
 	srv.reverseConnectActive[clientURL]++

--- a/server/reverse_connect.go
+++ b/server/reverse_connect.go
@@ -3,6 +3,7 @@
 package server
 
 import (
+	"context"
 	"net"
 	"net/url"
 	"sync"
@@ -12,7 +13,21 @@ import (
 )
 
 func (srv *Server) reverseConnect(wg *sync.WaitGroup) {
-	srv.reverseConnectOnce(wg)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	defer func() {
+		close(done)
+		cancel()
+	}()
+	go func() {
+		select {
+		case <-srv.closing:
+			cancel()
+		case <-done:
+		}
+	}()
+
+	srv.reverseConnectOnce(ctx, wg)
 	ticker := time.NewTicker(srv.reverseConnectInterval)
 	defer ticker.Stop()
 	for {
@@ -20,14 +35,14 @@ func (srv *Server) reverseConnect(wg *sync.WaitGroup) {
 		case <-srv.closing:
 			return
 		case <-ticker.C:
-			srv.reverseConnectOnce(wg)
+			srv.reverseConnectOnce(ctx, wg)
 		}
 	}
 }
 
-func (srv *Server) reverseConnectOnce(wg *sync.WaitGroup) {
-	timeout := srv.reverseConnectInterval
-	if timeout <= 0 || timeout > 3*time.Second {
+func (srv *Server) reverseConnectOnce(ctx context.Context, wg *sync.WaitGroup) {
+	timeout := srv.reverseConnectTimeout
+	if timeout <= 0 {
 		timeout = 3 * time.Second
 	}
 	for _, clientURL := range srv.reverseConnectURLs {
@@ -43,7 +58,9 @@ func (srv *Server) reverseConnectOnce(wg *sync.WaitGroup) {
 		if !srv.beginReverseConnect(clientURL) {
 			continue
 		}
-		conn, err := net.DialTimeout("tcp", u.Host, timeout)
+		dialCtx, cancel := context.WithTimeout(ctx, timeout)
+		conn, err := new(net.Dialer).DialContext(dialCtx, "tcp", u.Host)
+		cancel()
 		if err != nil {
 			srv.endReverseConnect(clientURL)
 			continue

--- a/server/reverse_connect.go
+++ b/server/reverse_connect.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/awcullen/opcua/ua"
 )
 
 func (srv *Server) reverseConnect(wg *sync.WaitGroup) {
@@ -38,11 +40,47 @@ func (srv *Server) reverseConnectOnce(wg *sync.WaitGroup) {
 		if err != nil {
 			continue
 		}
+		if !srv.beginReverseConnect(clientURL) {
+			continue
+		}
 		conn, err := net.DialTimeout("tcp", u.Host, timeout)
 		if err != nil {
+			srv.endReverseConnect(clientURL)
 			continue
 		}
 		wg.Add(1)
-		go srv.handleReverseConnection(conn, wg)
+		go srv.handleReverseConnection(conn, wg, clientURL)
 	}
+}
+
+func (srv *Server) beginReverseConnect(clientURL string) bool {
+	srv.reverseConnectMu.Lock()
+	defer srv.reverseConnectMu.Unlock()
+	if srv.reverseConnectActive[clientURL] > 0 {
+		return false
+	}
+	if until := srv.reverseConnectRejectedUntil[clientURL]; time.Now().Before(until) {
+		return false
+	}
+	srv.reverseConnectActive[clientURL]++
+	return true
+}
+
+func (srv *Server) endReverseConnect(clientURL string) {
+	srv.reverseConnectMu.Lock()
+	defer srv.reverseConnectMu.Unlock()
+	if srv.reverseConnectActive[clientURL] <= 1 {
+		delete(srv.reverseConnectActive, clientURL)
+		return
+	}
+	srv.reverseConnectActive[clientURL]--
+}
+
+func (srv *Server) rejectReverseConnect(clientURL string, err error) {
+	if err != ua.BadTCPMessageTypeInvalid {
+		return
+	}
+	srv.reverseConnectMu.Lock()
+	srv.reverseConnectRejectedUntil[clientURL] = time.Now().Add(srv.reverseConnectRejectTimeout)
+	srv.reverseConnectMu.Unlock()
 }

--- a/server/reverse_connect.go
+++ b/server/reverse_connect.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Converter Systems LLC. All rights reserved.
+
+package server
+
+import (
+	"net"
+	"net/url"
+	"sync"
+	"time"
+)
+
+func (srv *Server) reverseConnect(wg *sync.WaitGroup) {
+	srv.reverseConnectOnce(wg)
+	ticker := time.NewTicker(srv.reverseConnectInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-srv.closing:
+			return
+		case <-ticker.C:
+			srv.reverseConnectOnce(wg)
+		}
+	}
+}
+
+func (srv *Server) reverseConnectOnce(wg *sync.WaitGroup) {
+	timeout := srv.reverseConnectInterval
+	if timeout <= 0 || timeout > 3*time.Second {
+		timeout = 3 * time.Second
+	}
+	for _, clientURL := range srv.reverseConnectURLs {
+		select {
+		case <-srv.closing:
+			return
+		default:
+		}
+		u, err := url.Parse(clientURL)
+		if err != nil {
+			continue
+		}
+		conn, err := net.DialTimeout("tcp", u.Host, timeout)
+		if err != nil {
+			continue
+		}
+		wg.Add(1)
+		go srv.handleReverseConnection(conn, wg)
+	}
+}

--- a/server/reverse_connect_test.go
+++ b/server/reverse_connect_test.go
@@ -16,22 +16,23 @@ func TestReverseConnectStateSkipsActiveAndRejectedClientURLs(t *testing.T) {
 		reverseConnectRejectedUntil: make(map[string]time.Time),
 	}
 	clientURL := "opc.tcp://127.0.0.1:4840"
+	now := time.Now()
 
-	if !srv.beginReverseConnect(clientURL) {
+	if !srv.beginReverseConnect(clientURL, now) {
 		t.Fatal("expected first reverse connect attempt to start")
 	}
-	if srv.beginReverseConnect(clientURL) {
+	if srv.beginReverseConnect(clientURL, now) {
 		t.Fatal("expected active reverse connect attempt to block duplicate attempts")
 	}
 
 	srv.rejectReverseConnect(clientURL, ua.BadTCPMessageTypeInvalid)
 	srv.endReverseConnect(clientURL)
-	if srv.beginReverseConnect(clientURL) {
+	if srv.beginReverseConnect(clientURL, now) {
 		t.Fatal("expected rejected reverse connect attempt to back off")
 	}
 
 	srv.reverseConnectRejectedUntil[clientURL] = time.Now().Add(-time.Second)
-	if !srv.beginReverseConnect(clientURL) {
+	if !srv.beginReverseConnect(clientURL, now) {
 		t.Fatal("expected reverse connect attempt after reject timeout")
 	}
 }
@@ -43,9 +44,10 @@ func BenchmarkBeginReverseConnect(b *testing.B) {
 		reverseConnectRejectedUntil: make(map[string]time.Time),
 	}
 	clientURL := "opc.tcp://127.0.0.1:4840"
+	now := time.Now()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if !srv.beginReverseConnect(clientURL) {
+		if !srv.beginReverseConnect(clientURL, now) {
 			b.Fatal("expected reverse connect to start")
 		}
 		srv.endReverseConnect(clientURL)
@@ -61,9 +63,10 @@ func BenchmarkBeginReverseConnectRejected(b *testing.B) {
 		},
 	}
 	clientURL := "opc.tcp://127.0.0.1:4840"
+	now := time.Now()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if srv.beginReverseConnect(clientURL) {
+		if srv.beginReverseConnect(clientURL, now) {
 			b.Fatal("expected reverse connect to back off")
 		}
 	}

--- a/server/reverse_connect_test.go
+++ b/server/reverse_connect_test.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Converter Systems LLC. All rights reserved.
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/awcullen/opcua/ua"
+)
+
+func TestReverseConnectStateSkipsActiveAndRejectedClientURLs(t *testing.T) {
+	srv := &Server{
+		reverseConnectRejectTimeout: time.Minute,
+		reverseConnectActive:        make(map[string]int),
+		reverseConnectRejectedUntil: make(map[string]time.Time),
+	}
+	clientURL := "opc.tcp://127.0.0.1:4840"
+
+	if !srv.beginReverseConnect(clientURL) {
+		t.Fatal("expected first reverse connect attempt to start")
+	}
+	if srv.beginReverseConnect(clientURL) {
+		t.Fatal("expected active reverse connect attempt to block duplicate attempts")
+	}
+
+	srv.rejectReverseConnect(clientURL, ua.BadTCPMessageTypeInvalid)
+	srv.endReverseConnect(clientURL)
+	if srv.beginReverseConnect(clientURL) {
+		t.Fatal("expected rejected reverse connect attempt to back off")
+	}
+
+	srv.reverseConnectRejectedUntil[clientURL] = time.Now().Add(-time.Second)
+	if !srv.beginReverseConnect(clientURL) {
+		t.Fatal("expected reverse connect attempt after reject timeout")
+	}
+}

--- a/server/reverse_connect_test.go
+++ b/server/reverse_connect_test.go
@@ -35,3 +35,36 @@ func TestReverseConnectStateSkipsActiveAndRejectedClientURLs(t *testing.T) {
 		t.Fatal("expected reverse connect attempt after reject timeout")
 	}
 }
+
+func BenchmarkBeginReverseConnect(b *testing.B) {
+	srv := &Server{
+		reverseConnectRejectTimeout: time.Minute,
+		reverseConnectActive:        make(map[string]int),
+		reverseConnectRejectedUntil: make(map[string]time.Time),
+	}
+	clientURL := "opc.tcp://127.0.0.1:4840"
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if !srv.beginReverseConnect(clientURL) {
+			b.Fatal("expected reverse connect to start")
+		}
+		srv.endReverseConnect(clientURL)
+	}
+}
+
+func BenchmarkBeginReverseConnectRejected(b *testing.B) {
+	srv := &Server{
+		reverseConnectRejectTimeout: time.Minute,
+		reverseConnectActive:        make(map[string]int),
+		reverseConnectRejectedUntil: map[string]time.Time{
+			"opc.tcp://127.0.0.1:4840": time.Now().Add(time.Minute),
+		},
+	}
+	clientURL := "opc.tcp://127.0.0.1:4840"
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if srv.beginReverseConnect(clientURL) {
+			b.Fatal("expected reverse connect to back off")
+		}
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -65,6 +65,10 @@ type Server struct {
 	maxWorkerThreads                     int
 	reverseConnectURLs                   []string
 	reverseConnectInterval               time.Duration
+	reverseConnectRejectTimeout          time.Duration
+	reverseConnectMu                     sync.Mutex
+	reverseConnectActive                 map[string]int
+	reverseConnectRejectedUntil          map[string]time.Time
 	serverDiagnostics                    bool
 	trace                                bool
 	localCertificate                     []byte
@@ -113,6 +117,9 @@ func New(localDescription ua.ApplicationDescription, certPath, keyPath, endpoint
 		maxChunkCount:                      defaultMaxChunkCount,
 		maxWorkerThreads:                   defaultMaxWorkerThreads,
 		reverseConnectInterval:             5 * time.Second,
+		reverseConnectRejectTimeout:        time.Minute,
+		reverseConnectActive:               make(map[string]int),
+		reverseConnectRejectedUntil:        make(map[string]time.Time),
 		serverDiagnostics:                  true,
 		trace:                              false,
 		closing:                            make(chan struct{}),
@@ -427,9 +434,10 @@ func (srv *Server) handleConnection(conn net.Conn, wg *sync.WaitGroup) {
 	// log.Printf("Success closing secure channel '%d'.\n", ch.channelID)
 }
 
-func (srv *Server) handleReverseConnection(conn net.Conn, wg *sync.WaitGroup) {
+func (srv *Server) handleReverseConnection(conn net.Conn, wg *sync.WaitGroup, clientURL string) {
 	defer conn.Close()
 	defer wg.Done()
+	defer srv.endReverseConnect(clientURL)
 	ch := newServerSecureChannel(srv, conn, srv.trace)
 	closing := make(chan struct{})
 	defer close(closing)
@@ -445,6 +453,7 @@ func (srv *Server) handleReverseConnection(conn net.Conn, wg *sync.WaitGroup) {
 	}
 	err := ch.Open()
 	if err != nil {
+		srv.rejectReverseConnect(clientURL, err)
 		if c, ok := err.(ua.StatusCode); ok {
 			ch.Abort(c, "")
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -65,6 +65,7 @@ type Server struct {
 	maxWorkerThreads                     int
 	reverseConnectURLs                   []string
 	reverseConnectInterval               time.Duration
+	reverseConnectTimeout                time.Duration
 	reverseConnectRejectTimeout          time.Duration
 	reverseConnectMu                     sync.Mutex
 	reverseConnectActive                 map[string]int
@@ -117,6 +118,7 @@ func New(localDescription ua.ApplicationDescription, certPath, keyPath, endpoint
 		maxChunkCount:                      defaultMaxChunkCount,
 		maxWorkerThreads:                   defaultMaxWorkerThreads,
 		reverseConnectInterval:             5 * time.Second,
+		reverseConnectTimeout:              3 * time.Second,
 		reverseConnectRejectTimeout:        time.Minute,
 		reverseConnectActive:               make(map[string]int),
 		reverseConnectRejectedUntil:        make(map[string]time.Time),

--- a/server/server.go
+++ b/server/server.go
@@ -63,6 +63,8 @@ type Server struct {
 	maxMessageSize                       uint32
 	maxChunkCount                        uint32
 	maxWorkerThreads                     int
+	reverseConnectURLs                   []string
+	reverseConnectInterval               time.Duration
 	serverDiagnostics                    bool
 	trace                                bool
 	localCertificate                     []byte
@@ -110,6 +112,7 @@ func New(localDescription ua.ApplicationDescription, certPath, keyPath, endpoint
 		maxMessageSize:                     defaultMaxMessageSize,
 		maxChunkCount:                      defaultMaxChunkCount,
 		maxWorkerThreads:                   defaultMaxWorkerThreads,
+		reverseConnectInterval:             5 * time.Second,
 		serverDiagnostics:                  true,
 		trace:                              false,
 		closing:                            make(chan struct{}),
@@ -310,7 +313,19 @@ func (srv *Server) ListenAndServe() error {
 	}()
 
 	var wg sync.WaitGroup
+	var reverseDone chan struct{}
+	if len(srv.reverseConnectURLs) > 0 {
+		reverseDone = make(chan struct{})
+		go func() {
+			srv.reverseConnect(&wg)
+			close(reverseDone)
+		}()
+	}
 	err = srv.serve(ln, &wg)
+
+	if reverseDone != nil {
+		<-reverseDone
+	}
 
 	// wait until channels closed
 	wg.Wait()
@@ -410,6 +425,32 @@ func (srv *Server) handleConnection(conn net.Conn, wg *sync.WaitGroup) {
 		return
 	}
 	// log.Printf("Success closing secure channel '%d'.\n", ch.channelID)
+}
+
+func (srv *Server) handleReverseConnection(conn net.Conn, wg *sync.WaitGroup) {
+	defer conn.Close()
+	defer wg.Done()
+	ch := newServerSecureChannel(srv, conn, srv.trace)
+	closing := make(chan struct{})
+	defer close(closing)
+	go func() {
+		select {
+		case <-srv.closing:
+			ch.Close()
+		case <-closing:
+		}
+	}()
+	if err := ch.writeReverseHello(); err != nil {
+		return
+	}
+	err := ch.Open()
+	if err != nil {
+		if c, ok := err.(ua.StatusCode); ok {
+			ch.Abort(c, "")
+		}
+		return
+	}
+	_ = srv.requestWorker(ch)
 }
 
 // requestWorker receives service requests from channel and processes them.

--- a/server/server_secure_channel.go
+++ b/server/server_secure_channel.go
@@ -250,6 +250,20 @@ func (ch *serverSecureChannel) Open() error {
 		}
 		// log.Printf("-> Hello { ver: %d, rec: %d, snd: %d, msg: %d, chk: %d, ep: %s }\n", remoteProtocolVersion, remoteReceiveBufferSize, remoteSendBufferSize, remoteMaxMessageSize, remoteMaxChunkCount, ch.endpointURL)
 
+	case ua.MessageTypeError:
+		if msgLen < 16 {
+			return ua.BadDecodingError
+		}
+		var remoteCode uint32
+		if err := dec.ReadUInt32(&remoteCode); err != nil {
+			return ua.BadDecodingError
+		}
+		var unused string
+		if err = dec.ReadString(&unused); err != nil {
+			return ua.BadDecodingError
+		}
+		return ua.StatusCode(remoteCode)
+
 	default:
 		return ua.BadDecodingError
 	}

--- a/server/server_secure_channel.go
+++ b/server/server_secure_channel.go
@@ -179,6 +179,24 @@ func (ch *serverSecureChannel) IsExpired() bool {
 	return time.Now().After(ch.tokenExpiration)
 }
 
+func (ch *serverSecureChannel) writeReverseHello() error {
+	buf := *(ch.bytesPool.Get().(*[]byte))
+	defer ch.bytesPool.Put(&buf)
+	writer := ua.NewWriter(buf)
+	enc := ua.NewBinaryEncoder(writer, ua.NewEncodingContext())
+	serverURI := ch.srv.localDescription.ApplicationURI
+	enc.WriteUInt32(ua.MessageTypeReverseHello)
+	enc.WriteUInt32(uint32(16 + len(serverURI) + len(ch.srv.endpointURL)))
+	enc.WriteString(serverURI)
+	enc.WriteString(ch.srv.endpointURL)
+	ch.conn.SetWriteDeadline(time.Now().Add(3000 * time.Millisecond))
+	if _, err := ch.write(writer.Bytes()); err != nil {
+		return ua.BadEncodingError
+	}
+	ch.conn.SetWriteDeadline(time.Time{})
+	return nil
+}
+
 // Open the secure channel to the remote endpoint.
 func (ch *serverSecureChannel) Open() error {
 	ch.Lock()

--- a/ua/binary_encoder.go
+++ b/ua/binary_encoder.go
@@ -30,7 +30,6 @@ var (
 	typeExtensionObject = reflect.TypeOf((*ExtensionObject)(nil)).Elem()
 	typeVariant         = reflect.TypeOf((*Variant)(nil)).Elem()
 	typeDiagnosticInfo  = reflect.TypeOf((*DiagnosticInfo)(nil)).Elem()
-	typeSliceOfByte     = reflect.TypeOf((*[]byte)(nil)).Elem()
 	nilPtr              = unsafe.Pointer(nil)
 )
 
@@ -792,8 +791,8 @@ func (enc *BinaryEncoder) WriteExtensionObject(value ExtensionObject) error {
 	// cast writer to BufferAt to access superpowers
 	if buf, ok := enc.w.(buffer.BufferAt); ok {
 		mark := buf.Len() // mark where length is written
-		bs := make([]byte, 4)
-		if _, err := buf.Write(bs); err != nil {
+		var bs [4]byte
+		if _, err := buf.Write(bs[:]); err != nil {
 			return BadEncodingError
 		}
 		start := buf.Len() // mark where encoding starts
@@ -801,19 +800,19 @@ func (enc *BinaryEncoder) WriteExtensionObject(value ExtensionObject) error {
 			return BadEncodingError
 		}
 		end := buf.Len() // mark where encoding ends
-		binary.LittleEndian.PutUint32(bs, uint32(end-start))
+		binary.LittleEndian.PutUint32(bs[:], uint32(end-start))
 		// write actual length at mark
-		if _, err := buf.WriteAt(bs, mark); err != nil {
+		if _, err := buf.WriteAt(bs[:], mark); err != nil {
 			return BadEncodingError
 		}
 		return nil
 	}
 
 	// fall back to using extra buffer
-	buf2 := *(bytesPool.Get().(*[]byte))
-	defer bytesPool.Put(&buf2)
-	var writer = NewWriter(buf2)
-	enc2 := NewBinaryEncoder(writer, enc.ec)
+	buf2 := bytesPool.Get().(*[]byte)
+	defer bytesPool.Put(buf2)
+	writer := Writer{s: *buf2}
+	enc2 := BinaryEncoder{w: &writer, ec: enc.ec}
 	if err := enc2.Encode(value); err != nil {
 		return BadEncodingError
 	}


### PR DESCRIPTION
## Summary
- Implements OPC UA reverse connect for clients and servers using the existing UA-TCP secure-channel flow after `ReverseHello`.
- Adds a client `ReverseConnectManager` that listens continuously, holds incoming reverse sockets, supports endpoint/ApplicationURI filtering, and allows shared manager use across dial attempts.
- Adds rejection behavior for unsupported or unmatched reverse connections by sending `BadTCPMessageTypeInvalid` TCP error frames.
- Adds server-side reverse-connect state: duplicate active attempts are skipped, rejected clients back off for a configurable timeout, and dial timeout is configurable separately from retry interval.
- Covers anonymous reverse connect, secure reverse connect after discovery, shared manager use, endpoint mismatch rejection, server URI filtering, hold-time rejection, server retry/backoff state, and benchmarks for the hot paths.

Fixes https://github.com/awcullen/opcua/issues/45

Reference behavior: https://github.com/OPCFoundation/UA-.NETStandard/blob/master/Docs%2FReverseConnect.md

## Performance
- Reuses the existing secure-channel implementation after the initial reverse socket is selected.
- Parses `ReverseHello` directly from pooled buffers instead of allocating decoder strings on the validation path.
- Uses pooled TCP error-frame buffers for reverse rejection responses.
- Keeps server reverse-connect state map operations allocation-free on the benchmarked active/rejected paths.
- Reduces `WriteExtensionObject` fallback heap churn by preserving the pooled slice pointer, stack-allocating nested encoder/writer values, and using a stack length buffer for `BufferAt` writers.
- Avoids repeated `time.Now()` calls inside the reverse-connect active/rejected state check by passing one timestamp through each scan.

Latest benchmark run:

```text
BenchmarkReadReverseHello-8                       54.36-57.36 ns/op   40 B/op   2 allocs/op
BenchmarkValidateReverseHelloServerURIFilter-8    71.04-72.17 ns/op   40 B/op   2 allocs/op
BenchmarkWriteReverseReject-8                     47.31-47.50 ns/op    0 B/op   0 allocs/op
BenchmarkReverseConnectionMatches-8                3.196-3.293 ns/op   0 B/op   0 allocs/op
BenchmarkAwcullenEncode-8                         275.2-277.6 ns/op  129 B/op   3 allocs/op
BenchmarkBeginReverseConnect-8                    48.50-48.72 ns/op    0 B/op   0 allocs/op
BenchmarkBeginReverseConnectRejected-8            15.00-15.04 ns/op    0 B/op   0 allocs/op
```

Compared with the previous profiled run, `BenchmarkAwcullenEncode` improved from about `296 ns/op`, `153-154 B/op`, `4 allocs/op` to `~276 ns/op`, `129 B/op`, `3 allocs/op`. `BenchmarkBeginReverseConnectRejected` improved from about `51 ns/op` to `~15 ns/op`.

## Validation
- `go test ./server -run TestReverseConnectStateSkipsActiveAndRejectedClientURLs -count=1`
- `go test -p 1 ./... -count=1`
- `go test -race -p 1 ./... -count=1`
- `go vet -stdmethods=false ./...`
- `staticcheck ./client ./server ./cmd/benchmark`
- `staticcheck ./ua` checked separately; remaining findings are existing unrelated `ua/binary_decoder.go` unused helper and deprecated CRL field use in `ua/certificate_helpers.go`.
- `go test ./cmd/benchmark ./server -run '^$' -bench 'Benchmark(AwcullenEncode|BeginReverseConnect)' -benchmem -count=5`
- `go test ./cmd/benchmark ./server -run '^$' -bench 'Benchmark(AwcullenEncode|BeginReverseConnect)' -benchmem -count=3`
- `go test ./client -run '^$' -bench 'Benchmark(ReadReverseHello|ValidateReverseHelloServerURIFilter|WriteReverseReject|ReverseConnectionMatches)' -benchmem -count=3`

## Static Analysis Notes
- Plain `go vet ./...` still reports the existing master warning in `ua/binary_decoder.go`: `method ReadByte(value *byte) error should have signature ReadByte() (byte, error)`. This branch does not touch that file; `go vet -stdmethods=false ./...` passes.
- Repo-wide `staticcheck ./...` runs with `staticcheck 2026.1`, but still reports existing findings outside this performance change, including deprecated `io/ioutil` in `cmd/gen_opcua`, an unused decoder helper, and deprecated CRL field use.
